### PR TITLE
Allow to read config file in the fixture folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+## Fixed
+ - make sure `_config.yml` can be read
+
 ## [0.1.2] - 2018-04-20]
 ### Fixed
  - `contentFor` for binary data

--- a/lib/core.js
+++ b/lib/core.js
@@ -84,6 +84,9 @@ export function createSandbox(Hexo, options) {
 
     const ctx = new Hexo(baseFolder, {silent: true})
 
+    // Bypass the package.json check and make sure the config file can be loaded
+    ctx.env.init = true
+
     return ctx.init()
       .then(() => {
         return Promise.each(options.plugins, pluginPath => {

--- a/specs/index.spec.js
+++ b/specs/index.spec.js
@@ -19,3 +19,14 @@ test(async t => {
   await process(ctx)
   t.is(ctx.locals.get('test-utils-example'), 'it works')
 })
+
+test('reads _config.yml', async t => {
+  const sandbox = createSandbox(Hexo, {
+    fixture_folder: path.join(__dirname, 'support', 'fixtures')
+  })
+
+  const ctx = await sandbox('configurable')
+
+  await process(ctx)
+  t.is(ctx.config['some-property'], 'some-value')
+})

--- a/specs/support/fixtures/configurable/_config.yml
+++ b/specs/support/fixtures/configurable/_config.yml
@@ -1,0 +1,1 @@
+some-property: some-value


### PR DESCRIPTION
By default, Hexo checks the base folder for the package.json
file and hexo key there to allow further processing.

To bypass that check, we can force ctx.env.init to be always true.