### PR TITLE
Bind helper to the context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Added
  - `hasRoute` can be called with regular expression
 
+### Changed
+ - `getHelper` returns a function already bound the the context, it's immediately callable
+
 ## [0.1.3] - 2018-04-22
 ### Fixed
  - make sure `_config.yml` can be read

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -16,10 +16,15 @@
  *
  * @param {HexoContext} ctx
  * @param {string} name - helper name
- * @return {Function} - a helper function
+ * @return {Function|null} - a helper function
  */
 export function getHelper(ctx, name) {
-  return ctx.extend.helper.get(name)
+  const helper = ctx.extend.helper.get(name)
+  if (!helper) {
+    return null
+  }
+
+  return helper.bind(ctx)
 }
 
 /**

--- a/specs/view_helpers/get_helper.spec.js
+++ b/specs/view_helpers/get_helper.spec.js
@@ -1,0 +1,26 @@
+import test from 'ava'
+import Hexo from 'hexo'
+import {createSandbox} from '../../lib'
+import {getHelper} from '../../lib/helpers'
+
+const sandbox = createSandbox(Hexo)
+
+test('retrieves helper function', async t => {
+  const ctx = await sandbox()
+  ctx.extend.helper.register('getRoutes', function () {
+    return this.route.list()
+  })
+
+  const helper = getHelper(ctx, 'getRoutes')
+
+  t.is(typeof helper, 'function')
+  t.deepEqual(helper(), []);
+})
+
+test('retrieves nothing if is missing', async t => {
+  const ctx = await sandbox()
+
+  const helper = getHelper(ctx, 'getRoutes')
+
+  t.is(helper, null)
+})


### PR DESCRIPTION
So the returned function is immediately callable.