### PR TITLE
Fix jsdoc createsandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+ - Fix return type of `sandboxFactoryFn`.
 
 ## [0.3.0]
 ### Added

--- a/lib/core.js
+++ b/lib/core.js
@@ -8,7 +8,7 @@
  * @param {string|object} options - a string with a fixture name or a configuration object
  * @param {string} options.fixtureName - a fixture name, the folder of the Hexo testing project
  * @param {boolean} options.skipInit - set to true if you don't want to initialize Hexo. Default: false
- * @return {HexoContext}
+ * @return {Promise<HexoContext>}
  */
 
 /**
@@ -46,7 +46,7 @@ import Promise from 'bluebird'
  * const Hexo = require('hexo')
  * const sandbox = createSandbox(Hexo)
  *
- * const ctx = sandbox()
+ * const ctx = await sandbox()
  *
  * @example <caption>Example with custom fixture</caption>
  * const {createSandbox} = require('hexo-test-utils')
@@ -58,7 +58,7 @@ import Promise from 'bluebird'
  * })
  *
  * // Create a context with a fixture folder set to '../fixtures/test1'
- * const ctx = sandbox('test1')
+ * const ctx = await sandbox('test1')
  *
  * @example <caption>Example with custom plugins</caption>
  * const {createSandbox} = require('hexo-test-utils')
@@ -72,7 +72,7 @@ import Promise from 'bluebird'
  *   ]
  * })
  *
- * const ctx = sandbox()
+ * const ctx = await sandbox()
  */
 export function createSandbox(Hexo, options) {
   options = {


### PR DESCRIPTION
The `sandboxFactoryFn` returned by `createSandBox` is async function because it will `await hexo.init()` when called.
Thus, the correct type of return value is `Promise<HexoContext>`.
Therefore, you can not operate `hexo` until you wait at `await hexo` or call `sandbox.then(x =>{})` to get the x parameter.